### PR TITLE
Issue in preview 

### DIFF
--- a/preview/src/pages/[...page].astro
+++ b/preview/src/pages/[...page].astro
@@ -2,12 +2,6 @@
 import Layout from '../layouts/Default.astro'
 import { pageFactory } from '@devprotocol/clubs-core'
 import sTokensViewer from '../../../src/index'
-
-export const { getStaticPaths } = pageFactory({
-	config: () => import.meta.env.PUBLIC_CLUBS_CONFIG,
-	plugins: { sTokensViewer },
-})
-
 const Content = Astro.props.component
 ---
 

--- a/preview/src/pages/[...page].astro
+++ b/preview/src/pages/[...page].astro
@@ -2,6 +2,16 @@
 import Layout from '../layouts/Default.astro'
 import { pageFactory } from '@devprotocol/clubs-core'
 import sTokensViewer from '../../../src/index'
+
+export async function getStaticPaths() {
+	const { getStaticPaths } = pageFactory({
+		config: () => import.meta.env.PUBLIC_CLUBS_CONFIG,
+		plugins: { sTokensViewer },
+	})
+
+	return getStaticPaths()
+}
+
 const Content = Astro.props.component
 ---
 

--- a/preview/src/pages/admin/[...page].astro
+++ b/preview/src/pages/admin/[...page].astro
@@ -3,10 +3,16 @@ import Admin from '@devprotocol/clubs-core/admin'
 import { adminFactory } from '@devprotocol/clubs-core'
 import sTokensViewer from '../../../../src/index'
 
-export const { getStaticPaths } = adminFactory({
-	config: () => import.meta.env.PUBLIC_CLUBS_CONFIG,
-	plugins: { sTokensViewer },
-})
+export async function getStaticPaths() {
+	const { getStaticPaths } = adminFactory({
+		config: () => import.meta.env.PUBLIC_CLUBS_CONFIG,
+		plugins: { sTokensViewer },
+	})
+
+	console.log('foo', await getStaticPaths())
+
+	return getStaticPaths()
+}
 
 const Content = Astro.props.component
 ---

--- a/preview/src/pages/admin/[...page].astro
+++ b/preview/src/pages/admin/[...page].astro
@@ -9,8 +9,6 @@ export async function getStaticPaths() {
 		plugins: { sTokensViewer },
 	})
 
-	console.log('foo', await getStaticPaths())
-
 	return getStaticPaths()
 }
 


### PR DESCRIPTION
When starting with preview and accessing a page, an exception occurs when the getStaticPath method is not found. This is a response to solve that problem.